### PR TITLE
Add adaptive local tutor prototype with RAG and JSON storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python
+__pycache__/
+*.pyc
+
+# Data files
+/data/*.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# thinkbot
-Think Critical, Learn Critical.
+# ThinkBot
+
+ThinkBot is a simple learning assistant that runs entirely on your machine. It
+uses a locally hosted small language model (e.g. **DeepSeek R1 0528 Qwen3 8B
+4bit** via [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai))
+and augments the model with your own PDF material. Student progress and quiz
+results are stored in small JSON files, making it easy to inspect or reset the
+state.
+
+## Features
+
+- **Retrieval‑Augmented Generation** – ingest PDFs and retrieve relevant
+  snippets during chat.
+- **Adaptive tutoring** – responses become simpler if the student struggles,
+  and more advanced when they do well.
+- **Random quizzing and scoring** – the bot occasionally asks short questions
+  and keeps track of correct answers for each student.
+- **Offline friendly** – all data and models stay on your machine.
+
+## Requirements
+
+- Python 3.9+
+- A locally running LLM exposing an OpenAI compatible chat completion API.
+  - Example with Ollama: `ollama run deepseek-r1:latest` and keep the server
+    running at `http://localhost:11434`.
+- Python dependencies listed in `requirements.txt`.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+```
+
+If your model endpoint differs, edit `API_URL` and `MODEL` at the top of
+`main.py`.
+
+## Usage
+
+1. **Ingest study material** (once per PDF):
+
+   ```bash
+   python main.py ingest path/to/lesson.pdf
+   ```
+
+2. **Start a tutoring session**:
+
+   ```bash
+   python main.py chat Alice
+   ```
+
+   Type your questions and the bot will answer using the retrieved context. It
+   may occasionally present a quiz. Type `exit` to finish the session. At the
+   end you will see your score. All progress is stored in `data/student_Alice.json`.
+
+## Data Storage
+
+The `data/` folder contains JSON files for the knowledge base and each
+student’s progress. These files are ignored by git by default.
+
+## Disclaimer
+
+ThinkBot is a prototype. It does not enforce strict curriculum design and
+relies on the quality of the underlying model and material. Review all content
+before using it in a learning environment.
+
+## License
+
+This project is released under the MIT license. See [LICENSE](LICENSE).
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,251 @@
+"""ThinkBot: A simple adaptive tutor using a local LLM and JSON storage.
+
+This script provides two commands:
+
+* ``ingest <pdf>`` - load a PDF into the local knowledge base.
+* ``chat <student_name>`` - start an interactive tutoring session.
+
+The tutor uses a locally hosted model that exposes an OpenAI compatible
+chat-completions API (for example LM Studio or Ollama). Update the
+``API_URL`` and ``MODEL`` constants if your setup differs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import requests
+from pypdf import PdfReader
+from sentence_transformers import SentenceTransformer
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DATA_DIR = Path("data")
+KNOWLEDGE_FILE = DATA_DIR / "knowledge.json"
+EMBED_MODEL = "all-MiniLM-L6-v2"
+API_URL = "http://localhost:11434/v1/chat/completions"  # LM Studio/Ollama
+MODEL = "deepseek-r1:latest"  # change if the local model name differs
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+def ensure_data_dir() -> None:
+    """Ensure the data directory exists."""
+    DATA_DIR.mkdir(exist_ok=True)
+
+
+def load_json(path: Path, default):
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return default
+
+
+def save_json(path: Path, data) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Knowledge base (very small JSON based vector store)
+# ---------------------------------------------------------------------------
+
+def load_knowledge() -> List[dict]:
+    data = load_json(KNOWLEDGE_FILE, {"chunks": []})
+    return data["chunks"]
+
+
+def save_knowledge(chunks: List[dict]) -> None:
+    save_json(KNOWLEDGE_FILE, {"chunks": chunks})
+
+
+def embed_texts(texts: List[str]) -> List[List[float]]:
+    model = SentenceTransformer(EMBED_MODEL)
+    vectors = model.encode(texts, show_progress_bar=False)
+    return [vec.tolist() for vec in vectors]
+
+
+def ingest_pdf(pdf_path: str) -> None:
+    """Parse a PDF, chunk text and store embeddings."""
+    ensure_data_dir()
+    reader = PdfReader(pdf_path)
+    full_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    words = full_text.split()
+    chunk_size = 200  # words
+    chunks = [" ".join(words[i : i + chunk_size]) for i in range(0, len(words), chunk_size) if words[i : i + chunk_size]]
+    embeddings = embed_texts(chunks)
+    kb_chunks = load_knowledge()
+    for text, emb in zip(chunks, embeddings):
+        kb_chunks.append({"text": text, "embedding": emb})
+    save_knowledge(kb_chunks)
+    print(f"Ingested {len(chunks)} chunks into the knowledge base.")
+
+
+def retrieve(query: str, k: int = 3) -> List[str]:
+    chunks = load_knowledge()
+    if not chunks:
+        return []
+    model = SentenceTransformer(EMBED_MODEL)
+    q_emb = model.encode([query])[0]
+    # compute cosine similarity
+    chunk_embs = np.array([c["embedding"] for c in chunks])
+    scores = chunk_embs @ q_emb / (np.linalg.norm(chunk_embs, axis=1) * np.linalg.norm(q_emb) + 1e-9)
+    top_indices = scores.argsort()[-k:][::-1]
+    return [chunks[i]["text"] for i in top_indices]
+
+
+# ---------------------------------------------------------------------------
+# LLM client
+# ---------------------------------------------------------------------------
+
+def call_llm(messages: List[dict]) -> str:
+    payload = {"model": MODEL, "messages": messages}
+    try:
+        resp = requests.post(API_URL, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+    except Exception as exc:  # pragma: no cover - networking
+        return f"[Error contacting LLM: {exc}]"
+
+
+# ---------------------------------------------------------------------------
+# Student profile handling
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StudentProfile:
+    name: str
+    quizzes: int = 0
+    correct: int = 0
+
+    @property
+    def accuracy(self) -> float:
+        return self.correct / self.quizzes if self.quizzes else 0.0
+
+    @property
+    def path(self) -> Path:
+        return DATA_DIR / f"student_{self.name}.json"
+
+    def save(self) -> None:
+        ensure_data_dir()
+        save_json(self.path, asdict(self))
+
+    @classmethod
+    def load(cls, name: str) -> "StudentProfile":
+        ensure_data_dir()
+        data = load_json(DATA_DIR / f"student_{name}.json", None)
+        if data:
+            return cls(**data)
+        return cls(name=name)
+
+    def record(self, correct: bool) -> None:
+        self.quizzes += 1
+        if correct:
+            self.correct += 1
+        self.save()
+
+
+# ---------------------------------------------------------------------------
+# Chat logic
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = (
+    "You are ThinkBot, an adaptive teaching assistant."
+    " Use the provided context to answer questions."
+    " Speak clearly and educationally."
+)
+
+
+def generate_quiz(context: str) -> str:
+    prompt = f"Create a single short quiz question based on: {context}".strip()
+    return call_llm([{"role": "user", "content": prompt}])
+
+
+def grade_answer(question: str, answer: str) -> tuple[bool, str]:
+    prompt = (
+        f"Question: {question}\n"
+        f"Student answer: {answer}\n"
+        "Respond with 'correct' or 'incorrect' followed by a short explanation."
+    )
+    result = call_llm([{"role": "user", "content": prompt}])
+    is_correct = result.lower().startswith("correct")
+    return is_correct, result
+
+
+def chat(student_name: str) -> None:
+    profile = StudentProfile.load(student_name)
+    print(f"Starting session for {student_name}. Type 'exit' to end.")
+    turns = 0
+    while True:
+        user_input = input("You: ")
+        if user_input.strip().lower() == "exit":
+            break
+        turns += 1
+        context = "\n".join(retrieve(user_input))
+        adapt = "" if profile.accuracy >= 0.5 else " Use simple language and more examples."
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT + adapt + f"\nContext:\n{context}"},
+            {"role": "user", "content": user_input},
+        ]
+        reply = call_llm(messages)
+        print(f"Tutor: {reply}")
+
+        # Random quiz every 3 turns on average
+        if random.random() < 1 / 3:
+            quiz_context = context or "general knowledge from the lesson"
+            question = generate_quiz(quiz_context)
+            print(f"\nQuiz: {question}")
+            answer = input("Your answer: ")
+            correct, feedback = grade_answer(question, answer)
+            profile.record(correct)
+            print(f"Tutor: {feedback}\n")
+
+    if profile.quizzes:
+        print(
+            f"Session complete. Score: {profile.correct}/{profile.quizzes}"
+            f" ({profile.accuracy*100:.1f}% correct)."
+        )
+    profile.save()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="ThinkBot adaptive tutor")
+    sub = parser.add_subparsers(dest="command")
+
+    p_ingest = sub.add_parser("ingest", help="Add a PDF to the knowledge base")
+    p_ingest.add_argument("pdf", help="Path to PDF file")
+
+    p_chat = sub.add_parser("chat", help="Start a tutoring session")
+    p_chat.add_argument("student", help="Student name")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "ingest":
+        ingest_pdf(args.pdf)
+    elif args.command == "chat":
+        chat(args.student)
+    else:
+        parser.print_help()
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+sentence-transformers
+pypdf
+numpy


### PR DESCRIPTION
## Summary
- add `main.py` CLI for ingesting PDFs and running an adaptive tutoring chat backed by a local LLM
- store knowledge and per-student progress in JSON files inside `data/`
- document setup and usage, including local model configuration

## Testing
- `python -m py_compile main.py`
- `pip install --disable-pip-version-check -r requirements.txt`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689ef2dd4fc0832f8478b2a62ac53e90