### PR TITLE
feat: add fastapi adaptive quiz demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 
 # Data files
 /data/*.json
+!data/questions.json

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # ThinkBot
 
-ThinkBot is a simple learning assistant that runs entirely on your machine. It
-uses a locally hosted small language model (e.g. **DeepSeek R1 0528 Qwen3 8B
-4bit** via [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai))
-and augments the model with your own PDF material. Student progress and quiz
+ThinkBot is a simple learning assistant that uses
+[Google's Gemini API](https://ai.google.dev/) to adapt to each learner. It
+augments the model with your own PDF material and tracks learner accuracy to
+adjust the difficulty of explanations and quizzes. Student progress and quiz
 results are stored in small JSON files, making it easy to inspect or reset the
-state.
+state. A small FastAPI service powers a web-based quiz demo that can be deployed
+to platforms like Vercel.
 
 ## Features
 
@@ -15,14 +16,16 @@ state.
   and more advanced when they do well.
 - **Random quizzing and scoring** – the bot occasionally asks short questions
   and keeps track of correct answers for each student.
-- **Offline friendly** – all data and models stay on your machine.
+- **Gemini powered** – uses the official `google-genai` SDK with the free
+  `gemini-2.5-flash` model. Thinking is disabled to stay within the free tier
+  limits.
+- **Web API & demo UI** – serve adaptive quiz questions via FastAPI and a
+  lightweight HTML/JS interface.
 
 ## Requirements
 
 - Python 3.9+
-- A locally running LLM exposing an OpenAI compatible chat completion API.
-  - Example with Ollama: `ollama run deepseek-r1:latest` and keep the server
-    running at `http://localhost:11434`.
+- A Google Gemini API key. Set the ``GEMINI_API_KEY`` environment variable.
 - Python dependencies listed in `requirements.txt`.
 
 ## Installation
@@ -33,7 +36,7 @@ source .venv/bin/activate  # or .venv\Scripts\activate on Windows
 pip install -r requirements.txt
 ```
 
-If your model endpoint differs, edit `API_URL` and `MODEL` at the top of
+If your model endpoint or key differs, edit the constants at the top of
 `main.py`.
 
 ## Usage
@@ -54,10 +57,25 @@ If your model endpoint differs, edit `API_URL` and `MODEL` at the top of
    may occasionally present a quiz. Type `exit` to finish the session. At the
    end you will see your score. All progress is stored in `data/student_Alice.json`.
 
+3. **Run the web demo**:
+
+   ```bash
+   export GEMINI_API_KEY="<your-key>"  # e.g. AIzaSy...
+   uvicorn api:app --reload
+   ```
+
+   Open `static/index.html` in your browser and interact with the quiz. The
+   server selects question difficulty based on your accuracy and uses Gemini for
+   feedback. This API structure is compatible with serverless hosts such as
+   Vercel.
+
 ## Data Storage
 
 The `data/` folder contains JSON files for the knowledge base and each
 student’s progress. These files are ignored by git by default.
+
+It also includes `questions.json`, a small sample bank of quiz questions at
+three difficulty levels used by the web demo.
 
 ## Disclaimer
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,78 @@
+"""FastAPI interface for ThinkBot.
+
+Serves quiz questions and records answers while using the Gemini API to
+provide feedback. Designed for deployment on services like Vercel.
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from main import StudentProfile, call_llm
+
+DATA_DIR = Path(__file__).parent / "data"
+QUESTIONS_FILE = DATA_DIR / "questions.json"
+
+with QUESTIONS_FILE.open("r", encoding="utf-8") as fh:
+    _raw_questions = json.load(fh)
+
+QUESTIONS = {level: qs for level, qs in _raw_questions.items()}
+QUESTION_INDEX = {
+    q["id"]: {**q, "difficulty": level}
+    for level, qs in QUESTIONS.items()
+    for q in qs
+}
+
+app = FastAPI(title="ThinkBot API")
+
+
+def select_question(profile: StudentProfile) -> dict:
+    """Select a question difficulty based on student accuracy."""
+    if profile.accuracy > 0.8:
+        level = "hard"
+    elif profile.accuracy < 0.5:
+        level = "easy"
+    else:
+        level = "medium"
+    q = random.choice(QUESTIONS[level])
+    return {**q, "difficulty": level}
+
+
+class AnswerPayload(BaseModel):
+    student: str
+    question_id: int
+    answer: str
+
+
+@app.get("/question")
+def get_question(student: str):
+    profile = StudentProfile.load(student)
+    q = select_question(profile)
+    return {
+        "id": q["id"],
+        "question": q["question"],
+        "difficulty": q["difficulty"],
+    }
+
+
+@app.post("/answer")
+def submit_answer(payload: AnswerPayload):
+    profile = StudentProfile.load(payload.student)
+    q = QUESTION_INDEX.get(payload.question_id)
+    if not q:
+        raise HTTPException(status_code=404, detail="Unknown question")
+    correct = payload.answer.strip().lower() == q["answer"].strip().lower()
+    profile.record(correct)
+    prompt = (
+        f"Question: {q['question']}\n"
+        f"Student answer: {payload.answer}\n"
+        f"Correct answer: {q['answer']}\n"
+        "Provide a short, encouraging explanation."
+    )
+    feedback = call_llm([{"role": "user", "content": prompt}])
+    return {"correct": correct, "feedback": feedback, "accuracy": profile.accuracy}
+

--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,14 @@
+{
+  "easy": [
+    {"id": 1, "question": "What is 1 + 1?", "answer": "2"},
+    {"id": 2, "question": "What is 2 + 0?", "answer": "2"}
+  ],
+  "medium": [
+    {"id": 3, "question": "What is 5 * 3?", "answer": "15"},
+    {"id": 4, "question": "What is 12 / 3?", "answer": "4"}
+  ],
+  "hard": [
+    {"id": 5, "question": "What is the derivative of x^2?", "answer": "2x"},
+    {"id": 6, "question": "Integrate 2x dx.", "answer": "x^2 + C"}
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-requests
 sentence-transformers
 pypdf
 numpy
+pytest
+google-genai
+fastapi
+uvicorn

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>ThinkBot Demo</title>
+</head>
+<body>
+  <h1>ThinkBot Adaptive Quiz</h1>
+  <div id="question"></div>
+  <input id="answer" placeholder="Your answer" />
+  <button onclick="submitAnswer()">Submit</button>
+  <pre id="feedback"></pre>
+
+  <script>
+    async function loadQuestion() {
+      const student = localStorage.getItem('student') || prompt('Your name?');
+      localStorage.setItem('student', student);
+      const res = await fetch(`/question?student=${student}`);
+      window.currentQuestion = await res.json();
+      document.getElementById('question').textContent = window.currentQuestion.question;
+    }
+    async function submitAnswer() {
+      const student = localStorage.getItem('student');
+      const answer = document.getElementById('answer').value;
+      const res = await fetch('/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ student, question_id: window.currentQuestion.id, answer })
+      });
+      const data = await res.json();
+      document.getElementById('feedback').textContent = `Correct: ${data.correct}\n${data.feedback}`;
+      document.getElementById('answer').value = '';
+      loadQuestion();
+    }
+    loadQuestion();
+  </script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,49 @@
+import api
+from fastapi.testclient import TestClient
+
+
+def setup_stub(monkeypatch, accuracy=0.0):
+    class StubProfile:
+        def __init__(self):
+            self.accuracy = accuracy
+            self.records = []
+
+        def record(self, correct):
+            self.records.append(correct)
+            if self.records:
+                self.accuracy = sum(self.records) / len(self.records)
+
+        @classmethod
+        def load(cls, name):
+            return cls()
+
+    monkeypatch.setattr(api, "StudentProfile", StubProfile)
+    return StubProfile
+
+
+def test_get_question_respects_accuracy(monkeypatch):
+    setup_stub(monkeypatch, accuracy=0.2)
+    monkeypatch.setattr(api.random, "choice", lambda seq: seq[0])
+    client = TestClient(api.app)
+    res = client.get("/question", params={"student": "Alice"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["difficulty"] == "easy"
+    assert data["id"] == api.QUESTIONS["easy"][0]["id"]
+
+
+def test_submit_answer_updates_accuracy(monkeypatch):
+    setup_stub(monkeypatch, accuracy=0.0)
+    captured = {}
+    monkeypatch.setattr(api, "call_llm", lambda messages: captured.setdefault("msg", messages) or "Good job")
+    client = TestClient(api.app)
+    q = api.QUESTIONS["easy"][0]
+    res = client.post(
+        "/answer",
+        json={"student": "Bob", "question_id": q["id"], "answer": q["answer"]},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["correct"] is True
+    assert data["accuracy"] == 1.0
+    assert captured["msg"][0]["content"].startswith("Question")

--- a/tests/test_call_llm.py
+++ b/tests/test_call_llm.py
@@ -1,0 +1,37 @@
+import types as pytypes
+
+import main
+
+
+class DummyClient:
+    def __init__(self, captured):
+        self.captured = captured
+
+        class Models:
+            def __init__(self, outer):
+                self.outer = outer
+
+            def generate_content(self, **kwargs):
+                outer = self.outer
+                outer.captured.update(kwargs)
+                return pytypes.SimpleNamespace(text="Hello")
+
+        self.models = Models(self)
+
+
+def test_call_llm(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(main, "GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(main.genai, "Client", lambda api_key=None: DummyClient(captured))
+
+    result = main.call_llm([{"role": "user", "content": "hi"}])
+    assert result == "Hello"
+    assert captured["model"] == main.GEMINI_MODEL
+    assert captured["config"].thinking_config.thinking_budget == 0
+    assert captured["contents"][0].role == "user"
+
+
+def test_call_llm_without_key(monkeypatch):
+    monkeypatch.setattr(main, "GEMINI_API_KEY", "")
+    result = main.call_llm([{"role": "user", "content": "hi"}])
+    assert "key" in result.lower()

--- a/tests/test_student_profile.py
+++ b/tests/test_student_profile.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+import main
+
+
+def test_record_and_accuracy(tmp_path, monkeypatch):
+    # Redirect data directory to a temp path to avoid touching real files
+    monkeypatch.setattr(main, "DATA_DIR", tmp_path)
+
+    profile = main.StudentProfile.load("Alice")
+    assert profile.accuracy == 0.0
+    profile.record(True)
+    assert profile.quizzes == 1
+    assert profile.correct == 1
+    assert profile.accuracy == 1.0
+    profile.record(False)
+    assert profile.quizzes == 2
+    assert profile.correct == 1
+    assert profile.accuracy == 0.5
+
+    # verify file written
+    data = json.loads((tmp_path / "student_Alice.json").read_text())
+    assert data["correct"] == 1
+    assert data["quizzes"] == 2


### PR DESCRIPTION
## Summary
- add FastAPI adaptive quiz API with Gemini feedback
- provide sample question bank and static HTML interface
- document running the web demo and deployment hints

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be7c6c6210832fb777e33eb9de30c9