### PR TITLE
feat: add fastapi adaptive quiz demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 
 # Data files
 /data/*.json
+!data/questions.json

--- a/README.md
+++ b/README.md
@@ -1,71 +1,40 @@
 # ThinkBot
 
-ThinkBot is a simple learning assistant that runs entirely on your machine. It
-uses a locally hosted small language model (e.g. **DeepSeek R1 0528 Qwen3 8B
-4bit** via [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai))
-and augments the model with your own PDF material. Student progress and quiz
-results are stored in small JSON files, making it easy to inspect or reset the
-state.
+ThinkBot is a tiny adaptive quiz demo that showcases how Gemini can power
+personalized learning on resource‑constrained platforms like the free Vercel
+hobby plan.  It serves a minimal HTML interface, tracks student accuracy in
+small JSON files, and calls Gemini's `gemini-2.5-flash` model using the public
+REST API with thinking disabled to conserve quota.
 
 ## Features
+- Lightweight FastAPI backend with a static front‑end served at the root path
+- Question bank with easy/medium/hard levels selected by learner accuracy
+- Student progress stored locally as `data/student_<name>.json`
+- Gemini feedback for each answer using a single low‑cost API request
 
-- **Retrieval‑Augmented Generation** – ingest PDFs and retrieve relevant
-  snippets during chat.
-- **Adaptive tutoring** – responses become simpler if the student struggles,
-  and more advanced when they do well.
-- **Random quizzing and scoring** – the bot occasionally asks short questions
-  and keeps track of correct answers for each student.
-- **Offline friendly** – all data and models stay on your machine.
+## Setup
+1. Install Python 3.9+ dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export your Gemini API key (free tier works):
+   ```bash
+   export GEMINI_API_KEY="<your-key>"
+   ```
+3. Run the development server:
+   ```bash
+   uvicorn api:app --reload
+   ```
+   Then open [http://localhost:8000/](http://localhost:8000/) to try the quiz.
 
-## Requirements
+The project structure is Vercel‑compatible: placing `api/index.py` at the repo
+root lets Vercel serve the FastAPI app without extra configuration.
 
-- Python 3.9+
-- A locally running LLM exposing an OpenAI compatible chat completion API.
-  - Example with Ollama: `ollama run deepseek-r1:latest` and keep the server
-    running at `http://localhost:11434`.
-- Python dependencies listed in `requirements.txt`.
-
-## Installation
-
+## Testing
+Run the automated tests to verify basic behaviour:
 ```bash
-python -m venv .venv
-source .venv/bin/activate  # or .venv\Scripts\activate on Windows
-pip install -r requirements.txt
+python -m pytest -q
 ```
 
-If your model endpoint differs, edit `API_URL` and `MODEL` at the top of
-`main.py`.
-
-## Usage
-
-1. **Ingest study material** (once per PDF):
-
-   ```bash
-   python main.py ingest path/to/lesson.pdf
-   ```
-
-2. **Start a tutoring session**:
-
-   ```bash
-   python main.py chat Alice
-   ```
-
-   Type your questions and the bot will answer using the retrieved context. It
-   may occasionally present a quiz. Type `exit` to finish the session. At the
-   end you will see your score. All progress is stored in `data/student_Alice.json`.
-
-## Data Storage
-
-The `data/` folder contains JSON files for the knowledge base and each
-student’s progress. These files are ignored by git by default.
-
-## Disclaimer
-
-ThinkBot is a prototype. It does not enforce strict curriculum design and
-relies on the quality of the underlying model and material. Review all content
-before using it in a learning environment.
-
 ## License
-
-This project is released under the MIT license. See [LICENSE](LICENSE).
-
+Released under the MIT License.  See [LICENSE](LICENSE).

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,91 @@
+"""FastAPI interface for ThinkBot.
+
+Serves quiz questions and records answers while using the Gemini API to
+provide feedback. Designed for deployment on services like Vercel.
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from main import StudentProfile, call_llm
+
+# locate project root (one directory above this file)
+ROOT_DIR = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT_DIR / "data"
+QUESTIONS_FILE = DATA_DIR / "questions.json"
+STATIC_DIR = ROOT_DIR / "static"
+
+with QUESTIONS_FILE.open("r", encoding="utf-8") as fh:
+    _raw_questions = json.load(fh)
+
+QUESTIONS = {level: qs for level, qs in _raw_questions.items()}
+QUESTION_INDEX = {
+    q["id"]: {**q, "difficulty": level}
+    for level, qs in QUESTIONS.items()
+    for q in qs
+}
+
+app = FastAPI(title="ThinkBot API")
+
+# serve static files and root index for convenience when deployed
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+@app.get("/", response_class=HTMLResponse)
+def root() -> str:
+    """Return the demo HTML page."""
+    index_path = STATIC_DIR / "index.html"
+    return index_path.read_text(encoding="utf-8")
+
+
+def select_question(profile: StudentProfile) -> dict:
+    """Select a question difficulty based on student accuracy."""
+    if profile.accuracy > 0.8:
+        level = "hard"
+    elif profile.accuracy < 0.5:
+        level = "easy"
+    else:
+        level = "medium"
+    q = random.choice(QUESTIONS[level])
+    return {**q, "difficulty": level}
+
+
+class AnswerPayload(BaseModel):
+    student: str
+    question_id: int
+    answer: str
+
+
+@app.get("/question")
+def get_question(student: str):
+    profile = StudentProfile.load(student)
+    q = select_question(profile)
+    return {
+        "id": q["id"],
+        "question": q["question"],
+        "difficulty": q["difficulty"],
+    }
+
+
+@app.post("/answer")
+def submit_answer(payload: AnswerPayload):
+    profile = StudentProfile.load(payload.student)
+    q = QUESTION_INDEX.get(payload.question_id)
+    if not q:
+        raise HTTPException(status_code=404, detail="Unknown question")
+    correct = payload.answer.strip().lower() == q["answer"].strip().lower()
+    profile.record(correct)
+    prompt = (
+        f"Question: {q['question']}\n"
+        f"Student answer: {payload.answer}\n"
+        f"Correct answer: {q['answer']}\n"
+        "Provide a short, encouraging explanation."
+    )
+    feedback = call_llm([{ "role": "user", "content": prompt }])
+    return {"correct": correct, "feedback": feedback, "accuracy": profile.accuracy}

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,1 @@
+from . import app

--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,14 @@
+{
+  "easy": [
+    {"id": 1, "question": "What is 1 + 1?", "answer": "2"},
+    {"id": 2, "question": "What is 2 + 0?", "answer": "2"}
+  ],
+  "medium": [
+    {"id": 3, "question": "What is 5 * 3?", "answer": "15"},
+    {"id": 4, "question": "What is 12 / 3?", "answer": "4"}
+  ],
+  "hard": [
+    {"id": 5, "question": "What is the derivative of x^2?", "answer": "2x"},
+    {"id": 6, "question": "Integrate 2x dx.", "answer": "x^2 + C"}
+  ]
+}

--- a/main.py
+++ b/main.py
@@ -1,127 +1,67 @@
-"""ThinkBot: A simple adaptive tutor using a local LLM and JSON storage.
+"""Core utilities for the ThinkBot demo.
 
-This script provides two commands:
-
-* ``ingest <pdf>`` - load a PDF into the local knowledge base.
-* ``chat <student_name>`` - start an interactive tutoring session.
-
-The tutor uses a locally hosted model that exposes an OpenAI compatible
-chat-completions API (for example LM Studio or Ollama). Update the
-``API_URL`` and ``MODEL`` constants if your setup differs.
+Provides a minimal Gemini client and a small JSON-based ``StudentProfile`` to
+keep resource usage low for free-tier hosting such as Vercel's hobby plan.
 """
 
 from __future__ import annotations
 
-import argparse
 import json
-import random
-import sys
-from dataclasses import dataclass, asdict
+import os
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import List
 
-import numpy as np
 import requests
-from pypdf import PdfReader
-from sentence_transformers import SentenceTransformer
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
+# Directory where student progress JSON files are stored
 DATA_DIR = Path("data")
-KNOWLEDGE_FILE = DATA_DIR / "knowledge.json"
-EMBED_MODEL = "all-MiniLM-L6-v2"
-API_URL = "http://localhost:11434/v1/chat/completions"  # LM Studio/Ollama
-MODEL = "deepseek-r1:latest"  # change if the local model name differs
 
+# Gemini configuration
+GEMINI_MODEL = "gemini-2.5-flash"
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 
-# ---------------------------------------------------------------------------
-# Utility functions
-# ---------------------------------------------------------------------------
-
-def ensure_data_dir() -> None:
-    """Ensure the data directory exists."""
-    DATA_DIR.mkdir(exist_ok=True)
-
-
-def load_json(path: Path, default):
-    if path.exists():
-        with path.open("r", encoding="utf-8") as fh:
-            return json.load(fh)
-    return default
-
-
-def save_json(path: Path, data) -> None:
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# Knowledge base (very small JSON based vector store)
-# ---------------------------------------------------------------------------
-
-def load_knowledge() -> List[dict]:
-    data = load_json(KNOWLEDGE_FILE, {"chunks": []})
-    return data["chunks"]
-
-
-def save_knowledge(chunks: List[dict]) -> None:
-    save_json(KNOWLEDGE_FILE, {"chunks": chunks})
-
-
-def embed_texts(texts: List[str]) -> List[List[float]]:
-    model = SentenceTransformer(EMBED_MODEL)
-    vectors = model.encode(texts, show_progress_bar=False)
-    return [vec.tolist() for vec in vectors]
-
-
-def ingest_pdf(pdf_path: str) -> None:
-    """Parse a PDF, chunk text and store embeddings."""
-    ensure_data_dir()
-    reader = PdfReader(pdf_path)
-    full_text = "\n".join(page.extract_text() or "" for page in reader.pages)
-    words = full_text.split()
-    chunk_size = 200  # words
-    chunks = [" ".join(words[i : i + chunk_size]) for i in range(0, len(words), chunk_size) if words[i : i + chunk_size]]
-    embeddings = embed_texts(chunks)
-    kb_chunks = load_knowledge()
-    for text, emb in zip(chunks, embeddings):
-        kb_chunks.append({"text": text, "embedding": emb})
-    save_knowledge(kb_chunks)
-    print(f"Ingested {len(chunks)} chunks into the knowledge base.")
-
-
-def retrieve(query: str, k: int = 3) -> List[str]:
-    chunks = load_knowledge()
-    if not chunks:
-        return []
-    model = SentenceTransformer(EMBED_MODEL)
-    q_emb = model.encode([query])[0]
-    # compute cosine similarity
-    chunk_embs = np.array([c["embedding"] for c in chunks])
-    scores = chunk_embs @ q_emb / (np.linalg.norm(chunk_embs, axis=1) * np.linalg.norm(q_emb) + 1e-9)
-    top_indices = scores.argsort()[-k:][::-1]
-    return [chunks[i]["text"] for i in top_indices]
-
-
-# ---------------------------------------------------------------------------
-# LLM client
-# ---------------------------------------------------------------------------
 
 def call_llm(messages: List[dict]) -> str:
-    payload = {"model": MODEL, "messages": messages}
+    """Call Gemini via its REST API and return the text response.
+
+    ``messages`` uses the familiar ``{"role": ..., "content": ...}`` format.
+    To conserve free-tier quotas we disable the "thinking" feature by setting
+    the ``thinkingBudget`` to zero.
+    """
+
+    if not GEMINI_API_KEY:
+        return "[Gemini API key not set]"
+
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{GEMINI_MODEL}:generateContent"
+    )
+    payload = {
+        "contents": [
+            {"role": m["role"], "parts": [{"text": m["content"]}]} for m in messages
+        ],
+        "generationConfig": {"thinkingConfig": {"thinkingBudget": 0}},
+    }
+    params = {"key": GEMINI_API_KEY}
     try:
-        resp = requests.post(API_URL, json=payload, timeout=60)
-        resp.raise_for_status()
-        data = resp.json()
-        return data["choices"][0]["message"]["content"].strip()
-    except Exception as exc:  # pragma: no cover - networking
-        return f"[Error contacting LLM: {exc}]"
+        r = requests.post(url, params=params, json=payload, timeout=15)
+        r.raise_for_status()
+        data = r.json()
+        return (
+            data.get("candidates", [{}])[0]
+            .get("content", {})
+            .get("parts", [{}])[0]
+            .get("text", "")
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        return f"[Gemini request failed: {exc}]"
 
 
 # ---------------------------------------------------------------------------
-# Student profile handling
+# Student profile storage
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class StudentProfile:
@@ -138,14 +78,17 @@ class StudentProfile:
         return DATA_DIR / f"student_{self.name}.json"
 
     def save(self) -> None:
-        ensure_data_dir()
-        save_json(self.path, asdict(self))
+        DATA_DIR.mkdir(exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(asdict(self), fh)
 
     @classmethod
     def load(cls, name: str) -> "StudentProfile":
-        ensure_data_dir()
-        data = load_json(DATA_DIR / f"student_{name}.json", None)
-        if data:
+        DATA_DIR.mkdir(exist_ok=True)
+        path = DATA_DIR / f"student_{name}.json"
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
             return cls(**data)
         return cls(name=name)
 
@@ -156,96 +99,6 @@ class StudentProfile:
         self.save()
 
 
-# ---------------------------------------------------------------------------
-# Chat logic
-# ---------------------------------------------------------------------------
-
-SYSTEM_PROMPT = (
-    "You are ThinkBot, an adaptive teaching assistant."
-    " Use the provided context to answer questions."
-    " Speak clearly and educationally."
-)
-
-
-def generate_quiz(context: str) -> str:
-    prompt = f"Create a single short quiz question based on: {context}".strip()
-    return call_llm([{"role": "user", "content": prompt}])
-
-
-def grade_answer(question: str, answer: str) -> tuple[bool, str]:
-    prompt = (
-        f"Question: {question}\n"
-        f"Student answer: {answer}\n"
-        "Respond with 'correct' or 'incorrect' followed by a short explanation."
-    )
-    result = call_llm([{"role": "user", "content": prompt}])
-    is_correct = result.lower().startswith("correct")
-    return is_correct, result
-
-
-def chat(student_name: str) -> None:
-    profile = StudentProfile.load(student_name)
-    print(f"Starting session for {student_name}. Type 'exit' to end.")
-    turns = 0
-    while True:
-        user_input = input("You: ")
-        if user_input.strip().lower() == "exit":
-            break
-        turns += 1
-        context = "\n".join(retrieve(user_input))
-        adapt = "" if profile.accuracy >= 0.5 else " Use simple language and more examples."
-        messages = [
-            {"role": "system", "content": SYSTEM_PROMPT + adapt + f"\nContext:\n{context}"},
-            {"role": "user", "content": user_input},
-        ]
-        reply = call_llm(messages)
-        print(f"Tutor: {reply}")
-
-        # Random quiz every 3 turns on average
-        if random.random() < 1 / 3:
-            quiz_context = context or "general knowledge from the lesson"
-            question = generate_quiz(quiz_context)
-            print(f"\nQuiz: {question}")
-            answer = input("Your answer: ")
-            correct, feedback = grade_answer(question, answer)
-            profile.record(correct)
-            print(f"Tutor: {feedback}\n")
-
-    if profile.quizzes:
-        print(
-            f"Session complete. Score: {profile.correct}/{profile.quizzes}"
-            f" ({profile.accuracy*100:.1f}% correct)."
-        )
-    profile.save()
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-
-def main(argv: List[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="ThinkBot adaptive tutor")
-    sub = parser.add_subparsers(dest="command")
-
-    p_ingest = sub.add_parser("ingest", help="Add a PDF to the knowledge base")
-    p_ingest.add_argument("pdf", help="Path to PDF file")
-
-    p_chat = sub.add_parser("chat", help="Start a tutoring session")
-    p_chat.add_argument("student", help="Student name")
-
-    args = parser.parse_args(argv)
-
-    if args.command == "ingest":
-        ingest_pdf(args.pdf)
-    elif args.command == "chat":
-        chat(args.student)
-    else:
-        parser.print_help()
-        return 1
-    return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
-
+if __name__ == "__main__":  # pragma: no cover
+    # small manual test when executed directly
+    print(call_llm([{"role": "user", "content": "Hello"}]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+fastapi
+uvicorn
 requests
-sentence-transformers
-pypdf
-numpy
+pytest

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>ThinkBot Demo</title>
+</head>
+<body>
+  <h1>ThinkBot Adaptive Quiz</h1>
+  <div id="question"></div>
+  <input id="answer" placeholder="Your answer" />
+  <button onclick="submitAnswer()">Submit</button>
+  <pre id="feedback"></pre>
+
+  <script>
+    async function loadQuestion() {
+      const student = localStorage.getItem('student') || prompt('Your name?');
+      localStorage.setItem('student', student);
+      const res = await fetch(`/question?student=${student}`);
+      window.currentQuestion = await res.json();
+      document.getElementById('question').textContent = window.currentQuestion.question;
+    }
+    async function submitAnswer() {
+      const student = localStorage.getItem('student');
+      const answer = document.getElementById('answer').value;
+      const res = await fetch('/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ student, question_id: window.currentQuestion.id, answer })
+      });
+      const data = await res.json();
+      document.getElementById('feedback').textContent = `Correct: ${data.correct}\n${data.feedback}`;
+      document.getElementById('answer').value = '';
+      loadQuestion();
+    }
+    loadQuestion();
+  </script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,56 @@
+import api
+from fastapi.testclient import TestClient
+
+
+def setup_stub(monkeypatch, accuracy=0.0):
+    class StubProfile:
+        def __init__(self):
+            self.accuracy = accuracy
+            self.records = []
+
+        def record(self, correct):
+            self.records.append(correct)
+            if self.records:
+                self.accuracy = sum(self.records) / len(self.records)
+
+        @classmethod
+        def load(cls, name):
+            return cls()
+
+    monkeypatch.setattr(api, "StudentProfile", StubProfile)
+    return StubProfile
+
+
+def test_get_question_respects_accuracy(monkeypatch):
+    setup_stub(monkeypatch, accuracy=0.2)
+    monkeypatch.setattr(api.random, "choice", lambda seq: seq[0])
+    client = TestClient(api.app)
+    res = client.get("/question", params={"student": "Alice"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["difficulty"] == "easy"
+    assert data["id"] == api.QUESTIONS["easy"][0]["id"]
+
+
+def test_submit_answer_updates_accuracy(monkeypatch):
+    setup_stub(monkeypatch, accuracy=0.0)
+    captured = {}
+    monkeypatch.setattr(api, "call_llm", lambda messages: captured.setdefault("msg", messages) or "Good job")
+    client = TestClient(api.app)
+    q = api.QUESTIONS["easy"][0]
+    res = client.post(
+        "/answer",
+        json={"student": "Bob", "question_id": q["id"], "answer": q["answer"]},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["correct"] is True
+    assert data["accuracy"] == 1.0
+    assert captured["msg"][0]["content"].startswith("Question")
+
+
+def test_root_serves_html():
+    client = TestClient(api.app)
+    res = client.get("/")
+    assert res.status_code == 200
+    assert "<!DOCTYPE html>" in res.text

--- a/tests/test_call_llm.py
+++ b/tests/test_call_llm.py
@@ -1,0 +1,31 @@
+import main
+
+
+def test_call_llm(monkeypatch):
+    captured = {}
+
+    def fake_post(url, params=None, json=None, timeout=None):
+        captured.update({"url": url, "params": params, "json": json})
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"candidates": [{"content": {"parts": [{"text": "Hello"}]}}]}
+
+        return Resp()
+
+    monkeypatch.setattr(main, "GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(main.requests, "post", fake_post)
+
+    result = main.call_llm([{"role": "user", "content": "hi"}])
+    assert result == "Hello"
+    assert "thinkingBudget" in captured["json"]["generationConfig"]["thinkingConfig"]
+    assert captured["json"]["contents"][0]["role"] == "user"
+
+
+def test_call_llm_without_key(monkeypatch):
+    monkeypatch.setattr(main, "GEMINI_API_KEY", "")
+    result = main.call_llm([{"role": "user", "content": "hi"}])
+    assert "key" in result.lower()

--- a/tests/test_student_profile.py
+++ b/tests/test_student_profile.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+import main
+
+
+def test_record_and_accuracy(tmp_path, monkeypatch):
+    # Redirect data directory to a temp path to avoid touching real files
+    monkeypatch.setattr(main, "DATA_DIR", tmp_path)
+
+    profile = main.StudentProfile.load("Alice")
+    assert profile.accuracy == 0.0
+    profile.record(True)
+    assert profile.quizzes == 1
+    assert profile.correct == 1
+    assert profile.accuracy == 1.0
+    profile.record(False)
+    assert profile.quizzes == 2
+    assert profile.correct == 1
+    assert profile.accuracy == 0.5
+
+    # verify file written
+    data = json.loads((tmp_path / "student_Alice.json").read_text())
+    assert data["correct"] == 1
+    assert data["quizzes"] == 2


### PR DESCRIPTION
## Summary
- replace heavy dependencies with a lightweight FastAPI+requests stack for Vercel deployment
- implement Gemini calls via REST API with thinking disabled and JSON-based student profiles
- document minimal setup for running the adaptive quiz demo on free tiers

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be7c6c6210832fb777e33eb9de30c9